### PR TITLE
implement a db cache of all elements in page

### DIFF
--- a/app/models/fe/element.rb
+++ b/app/models/fe/element.rb
@@ -72,9 +72,9 @@ module Fe
         page = page_element.page
       end
 
-      index = page.all_elements.pluck(:id).index(self.id)
-      if index > 0 && prev_el = page.all_elements[index-1]
-        return prev_el
+      index = page.all_element_ids_arr.index(self.id)
+      if index > 0 && prev_el_id = page.all_element_ids_arr[index-1]
+        return Fe::Element.find(prev_el_id)
       end
     end
 

--- a/app/models/fe/element.rb
+++ b/app/models/fe/element.rb
@@ -196,7 +196,7 @@ module Fe
     end
 
     def update_page_all_element_ids
-      pages.each do |p| p.rebuild_all_element_ids end
+      pages.reload.each do |p| p.rebuild_all_element_ids end
 
       [question_grid, question_grid_with_total].compact.each do |field|
         field.update_page_all_element_ids

--- a/app/models/fe/element.rb
+++ b/app/models/fe/element.rb
@@ -198,12 +198,8 @@ module Fe
     def update_page_all_element_ids
       pages.each do |p| p.rebuild_all_element_ids end
 
-      if question_grid
-        question_grid.update_page_all_element_ids
-      elsif question_grid_with_total
-        question_grid_with_total.update_page_all_element_ids
-      elsif choice_field
-        choice_field.update_page_all_element_ids
+      [question_grid, question_grid_with_total].compact.each do |field|
+        field.update_page_all_element_ids
       end
     end
 

--- a/app/models/fe/page.rb
+++ b/app/models/fe/page.rb
@@ -52,8 +52,9 @@ module Fe
     #   false
     # end
 
+    # returns true if there is a question element on the page, including one inside a grid
     def has_questions?
-      all_questions.present?
+      all_questions.any?
     end
 
     def all_questions
@@ -100,10 +101,6 @@ module Fe
 
     def started?(answer_sheet)
       all_elements.any? {|e| e.has_response?(answer_sheet)}
-    end
-
-    def has_questions?
-      all_elements.any? {|e| e.is_a?(Question)}
     end
 
     private

--- a/app/models/fe/page.rb
+++ b/app/models/fe/page.rb
@@ -57,7 +57,7 @@ module Fe
     end
 
     def all_questions
-      all_elements.where("kind NOT IN('Fe::Paragraph', 'Fe::Section', 'Fe::QuestionGrid', 'Fe::QuestionGridWithTotal')")
+      all_elements.questions
     end
 
     def questions_before_position(position)
@@ -66,14 +66,9 @@ module Fe
 
     # Include nested elements
     def all_elements
-      if all_element_ids.nil?
-        rebuild_all_element_ids
-        all_elements
-      else
-        ids = all_element_ids.split(',')
-        ids << 0 # in case there are no elements, the query breaks at IN ()
-        Element.where(id: ids).order(:position)
-      end
+      rebuild_all_element_ids if all_element_ids.nil?
+      ids = all_element_ids.split(',')
+      ids.present? ? Element.where(id: ids).order(:position) : Element.where("1 = 0")
     end
 
     def rebuild_all_element_ids

--- a/app/models/fe/page.rb
+++ b/app/models/fe/page.rb
@@ -67,9 +67,18 @@ module Fe
 
     # Include nested elements
     def all_elements
-      rebuild_all_element_ids if all_element_ids.nil?
-      ids = all_element_ids.split(',')
-      ids.present? ? Element.where(id: ids).order(ids.collect{ |id| "id=#{id} DESC" }.join(', ')) : Element.where("1 = 0")
+      ids = all_element_ids_arr
+      order = ids.collect{ |id| "id=#{id} DESC" }.join(', ')
+      ids.present? ? Element.where(id: ids).order(order) : Element.where("1 = 0")
+    end
+
+    def all_element_ids
+      rebuild_all_element_ids if self[:all_element_ids].nil?
+      self[:all_element_ids]
+    end
+
+    def all_element_ids_arr
+      @all_element_ids_arr ||= all_element_ids.split(',').collect(&:to_i)
     end
 
     def rebuild_all_element_ids

--- a/app/models/fe/page.rb
+++ b/app/models/fe/page.rb
@@ -98,8 +98,17 @@ module Fe
       end
     end
 
+    def hidden?(answer_sheet)
+      return false unless question_sheet.all_elements.where(conditional_type: 'Fe::Page', conditional_id: self).any?
+
+      # if any of the conditional questions matches, it's visible
+      !question_sheet.all_elements.where(conditional_type: 'Fe::Page', conditional_id: self).any?{ |e|
+        e.conditional_match(answer_sheet)
+      }
+    end
+
     def complete?(answer_sheet)
-      return true if question_sheet.hidden_pages(answer_sheet).include?(self)
+      return true if hidden?(answer_sheet)
       prev_el = nil
       all_elements.all? {|e| 
         complete = !e.required?(answer_sheet, self, prev_el) || e.has_response?(answer_sheet)

--- a/app/models/fe/question.rb
+++ b/app/models/fe/question.rb
@@ -248,9 +248,5 @@ module Fe
       false
     end
 
-    def required?(answer_sheet = nil)
-      super
-    end
-
   end
 end

--- a/app/models/fe/question_sheet.rb
+++ b/app/models/fe/question_sheet.rb
@@ -59,13 +59,6 @@ module Fe
       new_sheet
     end
 
-    # pages hidden by a conditional element
-    def hidden_pages(answer_sheet)
-      all_elements.where(conditional_type: 'Fe::Page').find_all{ |e| 
-        !e.conditional_match(answer_sheet)
-      }.collect(&:conditional)
-    end
-
     private
 
     # next unused label with "Untitled form" prefix

--- a/app/models/fe/question_sheet.rb
+++ b/app/models/fe/question_sheet.rb
@@ -37,15 +37,13 @@ module Fe
       all_elements.questions.count
     end
 
-    # returns all elements including ones inside a grid
     def elements
       pages.collect(&:elements).flatten
     end
 
     def all_elements
       element_ids = pages.pluck(:all_element_ids).join(',').split(',')
-      element_ids << 0 # in case there are no elements, the query breaks at IN ()
-      Element.where(id: element_ids.split(','))
+      element_ids.present? ? Element.where(id: element_ids) : Element.where("1 = 0")
     end
 
     # Pages get duplicated

--- a/app/models/fe/question_sheet.rb
+++ b/app/models/fe/question_sheet.rb
@@ -42,8 +42,8 @@ module Fe
     end
 
     def all_elements
-      element_ids = pages.pluck(:all_element_ids).join(',').split(',')
-      element_ids.present? ? Element.where(id: element_ids) : Element.where("1 = 0")
+      element_ids = pages.pluck(:all_element_ids).compact.join(',').split(',')
+      element_ids.present? ? Element.where(id: element_ids).order(element_ids.collect{ |id| "id=#{id} DESC" }.join(', ')) : Element.where("1 = 0")
     end
 
     # Pages get duplicated

--- a/app/models/fe/question_sheet.rb
+++ b/app/models/fe/question_sheet.rb
@@ -34,22 +34,18 @@ module Fe
 
     # count all questions including ones inside a grid
     def questions_count
-      parent_ids = elements.find_all{ |e| e.is_a?(Fe::QuestionGrid) }.collect(&:id)
-      count = questions.count
-      # grab all sub-elements in one query to speed things up a bit
-      while (sub_elements = Fe::Element.where(question_grid_id: parent_ids)).any?
-        count += sub_elements.to_a.count{ |e| e.is_a?(Fe::Question) }
-        parent_ids = sub_elements.find_all{ |e| e.is_a?(Fe::QuestionGrid) }.collect(&:id)
-      end
-      return count
+      all_elements.questions.count
     end
 
-    def questions
-      pages.collect(&:questions).flatten
-    end
-
+    # returns all elements including ones inside a grid
     def elements
       pages.collect(&:elements).flatten
+    end
+
+    def all_elements
+      element_ids = pages.pluck(:all_element_ids).join(',').split(',')
+      element_ids << 0 # in case there are no elements, the query breaks at IN ()
+      Element.where(id: element_ids.split(','))
     end
 
     # Pages get duplicated
@@ -67,8 +63,8 @@ module Fe
 
     # pages hidden by a conditional element
     def hidden_pages(answer_sheet)
-      elements.find_all{ |e| 
-        e.conditional.is_a?(Fe::Page) && !e.conditional_match(answer_sheet)
+      all_elements.where(conditional_type: 'Fe::Page').find_all{ |e| 
+        !e.conditional_match(answer_sheet)
       }.collect(&:conditional)
     end
 

--- a/app/views/fe/answer_pages/_element.html.erb
+++ b/app/views/fe/answer_pages/_element.html.erb
@@ -1,7 +1,7 @@
 <% if element.question? && element.default_label? && element.label.present? && !element.hide_label? -%>
   <label for="<%= dom_id(element) %>" class="desc">
     <%= raw element.label %>
-    <% if element.required?(@answer_sheet) -%><span class="required">required</span><% end -%>
+    <% if element.required?(@answer_sheet, @page) -%><span class="required">required</span><% end -%>
     <%= tip(element.tooltip) if element.tooltip.present? %>
   </label>
 <% end -%>

--- a/app/views/fe/answer_sheets/_page_link.html.erb
+++ b/app/views/fe/answer_sheets/_page_link.html.erb
@@ -2,6 +2,6 @@
 <% if session[:attempted_submit] && page_link.page.has_questions? %>
 	<% css_class = page_link.page.complete?(@answer_sheet) ? 'complete' : 'incomplete' %>
 <% end %>
-<%= li_page_active_if(@presenter.active_page && page_link.page == @presenter.active_page, :id => page_link.dom_id + '-li', :class => css_class, :style => ('display:none' if @answer_sheet.question_sheet.hidden_pages(@answer_sheet).include?(page_link.page))) do %>
+<%= li_page_active_if(@presenter.active_page && page_link.page == @presenter.active_page, :id => page_link.dom_id + '-li', :class => css_class, :style => ('display:none' if page_link.page.hidden?(@answer_sheet))) do %>
   <%= link_to_function(page_link.label, load_page_js(page_link), :id => page_link.dom_id + '-link', 'data-page-id' => page_link.dom_id, :class => 'page_link', :href => page_link.load_path) %>
 <% end -%>

--- a/app/views/fe/questions/fe/_checkbox_field.html.erb
+++ b/app/views/fe/questions/fe/_checkbox_field.html.erb
@@ -3,7 +3,7 @@
     <td>
       <label for="<%= dom_id(checkbox_field) %>" class="desc">
         <%= raw checkbox_field.label %>
-        <% if checkbox_field.required?(@answer_sheet) -%><span class="required">required</span><% end -%>
+        <% if checkbox_field.required?(@answer_sheet, @page) -%><span class="required">required</span><% end -%>
         <%= tip(checkbox_field.tooltip) if checkbox_field.tooltip.present? %>
       </label>
     </td>

--- a/app/views/fe/questions/fe/_question_grid.html.erb
+++ b/app/views/fe/questions/fe/_question_grid.html.erb
@@ -3,7 +3,7 @@
     <% if question_grid.label.present? && !question_grid.hide_label? -%>
       <label class="desc gridname">
 				<%= raw question_grid.label %>
-    		<% if question_grid.required?(@answer_sheet) -%><span class="required">required</span><% end -%>
+    		<% if question_grid.required?(@answer_sheet, @page) -%><span class="required">required</span><% end -%>
 			</label>
     <% end %>
     <div class="sub_q">

--- a/app/views/fe/questions/fe/_radio_button_field.html.erb
+++ b/app/views/fe/questions/fe/_radio_button_field.html.erb
@@ -1,11 +1,11 @@
 <% css_class = 'radio ' -%>
-<% css_class += 'required' if radio_button_field.required? %>
+<% css_class += 'required' if radio_button_field.required?(@answer_sheet, @page) %>
 <% if radio_button_field.hide_option_labels? && !['question_pages', 'question_sheets', 'elements'].include?(controller.controller_name) %>
   <tr id="<%= dom_id(radio_button_field) %>">
     <td class="col1">
       <label for="<%= dom_id(radio_button_field) %>" class="desc">
         <%= raw radio_button_field.label %>
-        <% if radio_button_field.required?(@answer_sheet) -%><span class="required">required</span><% end -%>
+        <% if radio_button_field.required?(@answer_sheet, @page) -%><span class="required">required</span><% end -%>
         <%= tip(radio_button_field.tooltip) if radio_button_field.tooltip.present? %>
       </label>
     </td>

--- a/app/views/fe/questions/fe/_reference_question.html.erb
+++ b/app/views/fe/questions/fe/_reference_question.html.erb
@@ -1,8 +1,8 @@
 <% reference = reference_question.response(@answer_sheet) %>
 <% reference ||= Fe::ReferenceSheet.new %>
-<% css_class = reference_question.required?(@answer_sheet) ? 'required' : '' %>
-<% email_css_class = reference_question.required?(@answer_sheet) ? 'required email email' : '' %>
-<% phone_css_class = reference_question.required?(@answer_sheet) ? 'required phone phone' : '' %>
+<% css_class = reference_question.required?(@answer_sheet, @page) ? 'required' : '' %>
+<% email_css_class = reference_question.required?(@answer_sheet, @page) ? 'required email email' : '' %>
+<% phone_css_class = reference_question.required?(@answer_sheet, @page) ? 'required phone phone' : '' %>
 <%#= hidden_field_tag "reference[#{reference.id}]", :class => reference_question.required? && !reference.email_sent? ? 'required' : '' %>
 <div id="<%= dom_id(reference_question) %>" class="reference_question">
   <ul class="questions level1">

--- a/db/migrate/20150504221439_add_all_element_ids_to_pages.rb
+++ b/db/migrate/20150504221439_add_all_element_ids_to_pages.rb
@@ -1,0 +1,5 @@
+class AddAllElementIdsToPages < ActiveRecord::Migration
+  def change
+    add_column Fe::Page.table_name, :all_element_ids, :string
+  end
+end

--- a/spec/dummy/db/migrate/20150504222619_add_all_element_ids_to_pages.fe_engine.rb
+++ b/spec/dummy/db/migrate/20150504222619_add_all_element_ids_to_pages.fe_engine.rb
@@ -1,0 +1,6 @@
+# This migration comes from fe_engine (originally 20150504221439)
+class AddAllElementIdsToPages < ActiveRecord::Migration
+  def change
+    add_column Fe::Page.table_name, :all_element_ids, :string
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150123215803) do
+ActiveRecord::Schema.define(version: 20150504222619) do
 
   create_table "create_fe_phone_numbers", force: true do |t|
     t.string   "number"
@@ -154,6 +154,7 @@ ActiveRecord::Schema.define(version: 20150123215803) do
     t.boolean  "hidden",                       default: false
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string   "all_element_ids"
   end
 
   create_table "fe_people", force: true do |t|

--- a/spec/factories/elements.rb
+++ b/spec/factories/elements.rb
@@ -17,6 +17,10 @@ FactoryGirl.define do
       kind   "Fe::QuestionGrid"
       style  "grid"
     end
+    factory :question_grid_with_total, class: Fe::QuestionGridWithTotal do
+      kind   "Fe::QuestionGridWithTotal"
+      style  "grid"
+    end
     factory :reference_element, class: Fe::ReferenceQuestion do
       kind   "Fe::ReferenceQuestion"
       style  "staff"

--- a/spec/models/fe/element_spec.rb
+++ b/spec/models/fe/element_spec.rb
@@ -244,4 +244,42 @@ describe Fe::Element do
       expect(page.elements.last.pages).to eq([page])
     end
   end
+  
+  context '#update_page_all_element_ids' do
+    it 'should rebuild all_element_ids in all pages' do
+      element1 = create(:text_field_element)
+      page1 = create(:page)
+      page2 = create(:page)
+      create(:page_element, page_id: page1.id, element_id: element1.id)
+      create(:page_element, page_id: page2.id, element_id: element1.id)
+      page1.update_column(:all_element_ids, nil)
+      page2.update_column(:all_element_ids, nil)
+      element1.pages.reload
+      element1.update_page_all_element_ids
+      expect(page1.reload.all_element_ids).to eq("#{element1.id}")
+      expect(page2.reload.all_element_ids).to eq("#{element1.id}")
+    end
+    it 'should rebuild all_element_ids when adding a question grid' do
+      page = create(:page)
+      grid = create(:question_grid)
+      create(:page_element, page_id: page.id, element_id: grid.id)
+      grid.pages.reload
+      textfield = create(:text_field_element, question_grid: grid)
+
+      page.update_column(:all_element_ids, nil)
+      textfield.update_page_all_element_ids
+      expect(page.reload.all_element_ids).to eq("#{grid.id},#{textfield.id}")
+    end
+    it 'should rebuild all_element_ids when adding a question grid with total' do
+      page = create(:page)
+      grid = create(:question_grid)
+      create(:page_element, page_id: page.id, element_id: grid.id)
+      grid.pages.reload
+      textfield = create(:text_field_element, question_grid: grid)
+
+      page.update_column(:all_element_ids, nil)
+      textfield.update_page_all_element_ids
+      expect(page.reload.all_element_ids).to eq("#{grid.id},#{textfield.id}")
+    end
+  end
 end

--- a/spec/models/fe/page_spec.rb
+++ b/spec/models/fe/page_spec.rb
@@ -138,4 +138,12 @@ describe Fe::Page do
       expect(p.all_element_ids).to eq("#{e.id},#{tf1.id},#{section.id},#{tf2.id}")
     end
   end
+  context '#all_element_ids' do
+    it 'should rebuild_all_element_ids first when not set' do
+      p = create(:page)
+      p.all_element_ids
+      p.reload
+      expect(p.all_element_ids).to eq('')
+    end
+  end
 end

--- a/spec/models/fe/page_spec.rb
+++ b/spec/models/fe/page_spec.rb
@@ -33,6 +33,8 @@ describe Fe::Page do
 
     # validate the page -- the next element after the conditional should not be required
     page = question_sheet.pages[3]
+    question_sheet.pages.reload
+    page.reload
     expect(page.complete?(application)).to eq(true)
 
     # make the answer to the conditional question 'yes' so that the next element shows up and is thus required
@@ -45,6 +47,12 @@ describe Fe::Page do
   end
 
   context '#all_elements' do
+    it 'should return elements in the same order the ids were given' do
+      p = create(:page, all_element_ids: '2,1')
+      e1 = create(:text_field_element)
+      e2 = create(:text_field_element)
+      expect(p.all_elements).to eq([e2,e1])
+    end
     it 'should include elements in a grid' do
       p = create(:page)
       e = create(:question_grid)
@@ -59,7 +67,7 @@ describe Fe::Page do
       section = create(:section, question_grid: e)
 
       p.reload # get the updated all_element_ids column
-      expect(p.all_elements).to eq([e, tf1, tf2, section])
+      expect(p.all_elements).to eq([e, tf1, section, tf2])
     end
     it 'should return an empty active record result set when no elements are added' do
       p = create(:page)
@@ -106,12 +114,12 @@ describe Fe::Page do
   context '#all_questions' do
     it 'should include elements in a grid with total' do
       p = create(:page)
-      e = create(:question_grid_with_total) # shouldn't be included in all_questions because it's a not a question
-      create(:page_element, page: p, element: e)
-      tf1 = create(:text_field_element, question_grid: e)
+      grid = create(:question_grid_with_total) # shouldn't be included in all_questions because it's a not a question
+      create(:page_element, page: p, element: grid, position: 1)
+      tf1 = create(:text_field_element, question_grid: grid)
       tf2 = create(:text_field_element) # add directly to page
-      create(:page_element, page: p, element: tf2)
-      section = create(:section, question_grid: e) # shouldn't be included in all_questions because it's not a question
+      create(:page_element, page: p, element: tf2, position: 2)
+      section = create(:section, question_grid: grid) # shouldn't be included in all_questions because it's not a question
       p.reload # get the updated all_element_ids column
       expect(p.all_questions).to eq([tf1, tf2])
     end
@@ -127,7 +135,7 @@ describe Fe::Page do
       section = create(:section, question_grid: e)
       p.update_column :all_element_ids, nil
       p.rebuild_all_element_ids
-      expect(p.all_element_ids).to eq("#{e.id},#{tf2.id},#{tf1.id},#{section.id}")
+      expect(p.all_element_ids).to eq("#{e.id},#{tf1.id},#{section.id},#{tf2.id}")
     end
   end
 end

--- a/spec/models/fe/question_sheet_spec.rb
+++ b/spec/models/fe/question_sheet_spec.rb
@@ -20,6 +20,30 @@ describe Fe::QuestionSheet do
   end
 
   context '#all_elements' do
+    it 'should return elements in the same order as the ids' do
+      s = create(:question_sheet)
+
+      # P1
+      p1 = create(:page, question_sheet: s)
+      tf1 = create(:text_field_element)
+      create(:page_element, page: p1, element: tf1)
+      tf2 = create(:text_field_element)
+      create(:page_element, page: p1, element: tf2)
+      p1.update_column(:all_element_ids, "#{tf2.id},#{tf1.id}")
+
+      # P2
+      p2 = create(:page, question_sheet: s)
+      tf3 = create(:text_field_element)
+      create(:page_element, page: p2, element: tf3)
+      tf4 = create(:text_field_element)
+      create(:page_element, page: p2, element: tf4)
+      p2.update_column(:all_element_ids, "#{tf4.id},#{tf3.id}")
+
+      p1.reload # get the updated all_element_ids column
+      p2.reload # get the updated all_element_ids column
+      expect(s.all_elements).to eq([tf2, tf1, tf4, tf3])
+    end
+
     it 'should include elements in a grid' do
       s = create(:question_sheet)
       p = create(:page, question_sheet: s)
@@ -30,7 +54,7 @@ describe Fe::QuestionSheet do
       create(:page_element, page: p, element: tf2)
       section = create(:section, question_grid: e)
       p.reload # get the updated all_element_ids column
-      expect(s.all_elements).to eq([e, tf1, tf2, section])
+      expect(s.all_elements).to eq([e, tf1, section, tf2])
     end
     it 'should include elements across multiple pages' do
       s = create(:question_sheet)
@@ -64,6 +88,12 @@ describe Fe::QuestionSheet do
       p1.reload # get the updated all_element_ids column
       p2.reload # get the updated all_element_ids column
       expect(s.all_elements).to eq([g1, tf1, s1, tf2, g2, tf3, s2, tf4])
+    end
+    it 'should handle pages with no elements' do
+      qs = create(:question_sheet)
+      p = create(:page)
+      qs.pages.reload
+      expect(qs.all_elements).to eq([])
     end
   end
 

--- a/spec/models/fe/question_sheet_spec.rb
+++ b/spec/models/fe/question_sheet_spec.rb
@@ -14,7 +14,7 @@ describe Fe::QuestionSheet do
       create(:page_element, page: p, element: e)
       create(:text_field_element, question_grid: e)
       create(:section, question_grid: e) # this shouldn't get counted
-      expect(s.questions.count).to eq(0)
+      p.reload # get the updated all_element_ids column
       expect(s.questions_count).to eq(1)
     end
   end

--- a/spec/models/fe/question_sheet_spec.rb
+++ b/spec/models/fe/question_sheet_spec.rb
@@ -18,4 +18,67 @@ describe Fe::QuestionSheet do
       expect(s.questions_count).to eq(1)
     end
   end
+
+  context '#all_elements' do
+    it 'should include elements in a grid' do
+      s = create(:question_sheet)
+      p = create(:page, question_sheet: s)
+      e = create(:question_grid)
+      create(:page_element, page: p, element: e)
+      tf1 = create(:text_field_element, question_grid: e)
+      tf2 = create(:text_field_element) # add directly to page
+      create(:page_element, page: p, element: tf2)
+      section = create(:section, question_grid: e)
+      p.reload # get the updated all_element_ids column
+      expect(s.all_elements).to eq([e, tf1, tf2, section])
+    end
+    it 'should include elements across multiple pages' do
+      s = create(:question_sheet)
+
+      # P1
+      p1 = create(:page, question_sheet: s)
+
+      # grid pg1
+      g1 = create(:question_grid)
+      create(:page_element, page: p1, element: g1)
+      tf1 = create(:text_field_element, question_grid: g1)
+      s1 = create(:section, question_grid: g1)
+
+      # tf added directly to pg1
+      tf2 = create(:text_field_element)
+      create(:page_element, page: p1, element: tf2)
+
+      # P2
+      p2 = create(:page, question_sheet: s)
+
+      # grid pg2
+      g2 = create(:question_grid)
+      create(:page_element, page: p2, element: g2)
+      tf3 = create(:text_field_element, question_grid: g2)
+      s2 = create(:section, question_grid: g2)
+
+      # tf added directly to pg2
+      tf4 = create(:text_field_element)
+      create(:page_element, page: p2, element: tf4)
+
+      p1.reload # get the updated all_element_ids column
+      p2.reload # get the updated all_element_ids column
+      expect(s.all_elements).to eq([g1, tf1, s1, tf2, g2, tf3, s2, tf4])
+    end
+  end
+
+  context '#elements' do
+    it 'should not include elements in a grid' do
+      s = create(:question_sheet)
+      p = create(:page, question_sheet: s)
+      e = create(:question_grid)
+      create(:page_element, page: p, element: e)
+      tf1 = create(:text_field_element, question_grid: e) # shouldn't be included because it's in grid
+      tf2 = create(:text_field_element)
+      create(:page_element, page: p, element: tf2)
+      create(:section, question_grid: e) # shouldn't be included because it's in grid
+      p.reload # get the updated all_element_ids column
+      expect(s.elements).to eq([e, tf2])
+    end
+  end
 end


### PR DESCRIPTION
@twinge 

this cache includes elements inside grids

this speeds up questionnaire rending by making it quicker to
determine if a page is completed or not (since we have to take questions
in grids into account in marking a page completed).  the questionnaire
has an completion icon indicator for each page, and without this it was
pretty slow, because it was recursively going through all the grids to
get their elements

also speeds up the questions count (used by panorama to show the percent
complete)