### PR TITLE
some of the ref access_keys were generating as the same

### DIFF
--- a/app/models/fe/reference_sheet.rb
+++ b/app/models/fe/reference_sheet.rb
@@ -5,6 +5,8 @@ module Fe
     include Fe::AnswerSheetConcern
     include Rails.application.routes.url_helpers
     include AASM
+    include AccessKeyGenerator
+
     self.table_name = "#{Fe.table_name_prefix}references"
     self.inheritance_column = 'fake'
 
@@ -75,10 +77,6 @@ module Fe
     end
 
     alias_method :applicant, :applicant_answer_sheet
-    def generate_access_key
-      @@nonce ||= 0
-      self.access_key = Digest::MD5.hexdigest(email + Time.now.strftime("%G-W%V-%uT%T%:z%L") + Fe::ReferenceSheet.maximum(:id).to_s + (@@nonce += 1).to_s)
-    end
 
     def frozen?
       !%w(started created).include?(self.status)

--- a/app/models/fe/reference_sheet.rb
+++ b/app/models/fe/reference_sheet.rb
@@ -76,7 +76,8 @@ module Fe
 
     alias_method :applicant, :applicant_answer_sheet
     def generate_access_key
-      self.access_key = Digest::MD5.hexdigest(email + Time.now.to_s)
+      @@nonce ||= 0
+      self.access_key = Digest::MD5.hexdigest(email + Time.now.strftime("%G-W%V-%uT%T%:z%L") + Fe::ReferenceSheet.maximum(:id).to_s + (@@nonce += 1).to_s)
     end
 
     def frozen?

--- a/lib/access_key_generator.rb
+++ b/lib/access_key_generator.rb
@@ -1,0 +1,12 @@
+require 'securerandom'
+
+module Fe
+  module AccessKeyGenerator
+    def generate_access_key
+      begin
+        self.access_key = SecureRandom.hex
+      end while self.class.exists?(access_key: access_key)
+      return access_key
+    end
+  end
+end

--- a/lib/fe/engine.rb
+++ b/lib/fe/engine.rb
@@ -38,6 +38,7 @@ module Fe
 
     config.to_prepare do
       require_dependency('distinct_distinct_patch.rb')
+      require_dependency('access_key_generator')
 
       # Loading concerns and dependencies here when running FE specs breaks the coverage report.  The
       # Rakefile will set SKIP_CONCERNS and SKIP_DECORATORS true and decorators/concerns are loaded from

--- a/spec/models/fe/reference_sheet_spec.rb
+++ b/spec/models/fe/reference_sheet_spec.rb
@@ -8,4 +8,17 @@ describe Fe::ReferenceSheet do
   # it { expect validate_presence_of :phone } # need to add started_at column
   # it { expect validate_presence_of :email } # need to add started_at column
   # it { expect validate_presence_of :relationship } # need to add started_at column
+  
+  context '#access_key' do
+    it 'should generate two different in the same second' do
+      # there's a small chance the first and second access keys generated will be in different seconds
+      # doing it 5 times should make it extremely to pass despite there being a bug
+      5.times do
+        r = Fe::ReferenceSheet.new email: 'tester@test.com'
+        k1 = r.generate_access_key
+        k2 = r.generate_access_key
+        expect(k1).to_not eq(k2)
+      end
+    end
+  end
 end


### PR DESCRIPTION
@twinge 

made it a lot more aggressive to not have any duplicates.  Seem
important otherwise people could just change their id by one and with
the same access_key they can access someone else's ref

I added these to the string the key is built off:

1 - milliseconds to the generate time
2 - the largest id in the reference sheets table
3 - a nonce on at the class level (in case generate_access_key happens
to get called multiple times before a save happens that would
incremement the largest id in the table)