### PR TITLE
Fix factory girl deprecation warning

### DIFF
--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -13,7 +13,7 @@ Rails.application.configure do
   config.eager_load = false
 
   # Configure static asset server for tests with Cache-Control for performance.
-  config.serve_static_assets  = true
+  config.serve_static_files  = true
   config.static_cache_control = 'public, max-age=3600'
 
   # Show full error reports and disable caching.

--- a/spec/factories/question_sheet.rb
+++ b/spec/factories/question_sheet.rb
@@ -3,7 +3,7 @@ FactoryGirl.define do
     sequence(:label) { |n| "Question Sheet #{n}"}
 
     factory :question_sheet_with_pages do
-      ignore do
+      transient do
         pages_count 5
       end
 


### PR DESCRIPTION
I was getting a warning from factory girl about the `ignore` call below that it should be `transient`.

When I tried to run the specs for `qe` locally I got a warning about the `serve_static_assets` below as well that it should be `serve_static_files`. Didn't quite get the specs running locally, but they run in Travis here anyway.