### PR TITLE
Fe pass a

### DIFF
--- a/app/assets/javascripts/fe/fe.public.nojquery.js
+++ b/app/assets/javascripts/fe/fe.public.nojquery.js
@@ -294,7 +294,7 @@
               //       immediately after submission - :onSuccess (for USCM which stays in the application vs. redirecting to the dashboard)
               var curr = $.fe.pageHandler.current_page;
               $.ajax({url: url, dataType:'script',
-                     data: {answer_sheet_type: answer_sheet_type},
+                     data: {answer_sheet_type: answer_sheet_type, a: $('input[type=hidden][name=a]').val()},
                      type:'post', 
                      beforeSend: function(xhr) {
                        $('body').trigger('ajax:loading', xhr);

--- a/app/controllers/fe/reference_sheets_controller.rb
+++ b/app/controllers/fe/reference_sheets_controller.rb
@@ -2,6 +2,7 @@
 class Fe::ReferenceSheetsController < Fe::AnswerSheetsController
   skip_before_filter :ssm_login_required, :login
   before_filter :edit_only, :except => [:edit]
+
   def edit
     @reference_sheet = @answer_sheet
     unless @answer_sheet

--- a/app/views/fe/answer_pages/_answer_page.html.erb
+++ b/app/views/fe/answer_pages/_answer_page.html.erb
@@ -9,6 +9,7 @@
 
       <% if @elements.length > 0 -%>
         <%= form_tag @presenter.active_page_link.save_path, :id => "#{page_dom}-form", :onsubmit => "$.fe.pageHandler.savePage($('#sp_application_55716-page_331')); return false;", :multipart => true do -%>
+          <%= hidden_field_tag 'a', params[:a] %>
           <ul class="questions" id="questions_list">
             <% previous_element = nil %>
             <% @elements.each do |element| %>


### PR DESCRIPTION
@twinge @draffensperger 

cap is having issues with submitting refs when not logged in, related to being redirect to login (it skips login for loading the ref but not submit).. if we pass in the access key ("a" param) each time, we can find the answer sheet by that and it will provide security that way, so that we can safely skip the login