### PR TITLE
match none selected for a multi-checkbox question with empty string

### DIFF
--- a/app/assets/javascripts/fe/fe.public.nojquery.js
+++ b/app/assets/javascripts/fe/fe.public.nojquery.js
@@ -334,7 +334,7 @@
       } else {
         vals = $([$element.find("input:visible, select:visible").val()]);
       }
-      match = $(matchable_answers).filter(vals).length > 0;
+      match = $(matchable_answers).filter(vals).length > 0 || (matchable_answers == "" && vals.length == 0);
 
       switch ($element.data('conditional_type')) {
         case 'Fe::Element':


### PR DESCRIPTION
in the conditional check.  This is used to make a "[ ] Current address is the same as permanent address" condition, so the following grid filled with current address fields is only shown if that checkbox matches none selected (in this case there's only one option)

@twinge 